### PR TITLE
Implement serde::StdError for Error

### DIFF
--- a/src/error.rs
+++ b/src/error.rs
@@ -33,5 +33,10 @@ impl serde::de::Error for Error {
     }
 }
 
+// Allow our use by crates that have serde's `std` feature enabled. serde
+// reexports `StdError` under both `serde::ser` and `serde::de`; we just have to
+// pick one.
+impl serde::ser::StdError for Error {}
+
 pub type Result<T> = core::result::Result<T, Error>;
 


### PR DESCRIPTION
This allows `hubpack` to be used by clients who are using serde with its `std` feature enabled.

Without this change, using `hubpack` with serde+std produces errors of the form

```
   Compiling hubpack v0.1.0 (/hubpack)
error[E0277]: the trait bound `error::Error: StdError` is not satisfied
   --> /hubpack/src/error.rs:24:6
    |
24  | impl serde::ser::Error for Error {
    |      ^^^^^^^^^^^^^^^^^ the trait `StdError` is not implemented for `error::Error`
    |
note: required by a bound in `serde::ser::Error`
   --> /home/john/.cargo/registry/src/github.com-1ecc6299db9ec823/serde-1.0.136/src/ser/mod.rs:183:1
    |
183 | declare_error_trait!(Error: Sized + StdError);
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `serde::ser::Error`
    = note: this error originates in the macro `declare_error_trait` (in Nightly builds, run with -Z macro-backtrace for more info)
```

More detail is here in serde itself: https://github.com/serde-rs/serde/blob/master/serde/src/std_error.rs