### PR TITLE
Derive `PartialEq` on `Error`

### DIFF
--- a/src/error.rs
+++ b/src/error.rs
@@ -33,5 +33,10 @@ impl serde::de::Error for Error {
     }
 }
 
+// Allow our use by crates that have serde's `std` feature enabled. serde
+// reexports `StdError` under both `serde::ser` and `serde::de`; we just have to
+// pick one.
+impl serde::ser::StdError for Error {}
+
 pub type Result<T> = core::result::Result<T, Error>;
 

--- a/src/error.rs
+++ b/src/error.rs
@@ -1,4 +1,4 @@
-#[derive(Copy, Clone, Debug, PartialEq)]
+#[derive(Copy, Clone, Debug, PartialEq, Eq)]
 pub enum Error {
     Custom,
     Overrun,

--- a/src/error.rs
+++ b/src/error.rs
@@ -1,4 +1,4 @@
-#[derive(Copy, Clone, Debug)]
+#[derive(Copy, Clone, Debug, PartialEq)]
 pub enum Error {
     Custom,
     Overrun,


### PR DESCRIPTION
I found myself wanting to stash an `Error` in a hubris ringbuf, which requires `PartialEq`.

This PR builds on #1 and includes its commit too.